### PR TITLE
Update notify plugin

### DIFF
--- a/packages/reg-notify-github-plugin/package.json
+++ b/packages/reg-notify-github-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "reg-notify-github-plugin",
+  "name": "@justpark/reg-notify-github-plugin",
   "version": "0.14.4",
   "description": "Notify reg-suit result to GitHub repository",
   "regSuitPlugin": {
@@ -19,7 +19,7 @@
     "name": "Quramy",
     "email": "yosuke.kurami@gmail.com"
   },
-  "repository": "git+https://github.com/reg-viz/reg-suit.git",
+  "repository": "https://github.com/justpark/reg-suit",
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "29.5.12",


### PR DESCRIPTION
Update `reg-notify-github-plugin` to remove the problematic way that it attempted to get the commit ID.
Instead that value is now read from an env variable `COMMIT_INFO_SHA`

Fixes 
```
[reg-suit] error An error occurs during notify:
[reg-suit] error  RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 8573568. Received 35_369_863_136_411_650
    at new NodeError (node:internal/errors:405:5)
    at boundsError (node:internal/buffer:88:9)
    at Buffer.readUInt32BE (node:internal/buffer:311:5)
    at setupPackedIndexMap (/app/node_modules/tiny-commit-walker/dist/pack.js:76:40)
    at Packs.initializeSync (/app/node_modules/tiny-commit-walker/dist/pack.js:165:13)
    at Repository.readHeadSync (/app/node_modules/tiny-commit-walker/dist/repo.js:253:40)
    at GitHubNotifierPlugin.<anonymous> (/app/node_modules/reg-notify-github-plugin/lib/github-notifier-plugin.js:65:37)
    at Generator.next (<anonymous>)
    at /app/node_modules/reg-notify-github-plugin/lib/github-notifier-plugin.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/app/node_modules/reg-notify-github-plugin/lib/github-notifier-plugin.js:4:12)
    at GitHubNotifierPlugin.notify (/app/node_modules/reg-notify-github-plugin/lib/github-notifier-plugin.js:64:16)
    at /app/node_modules/reg-suit-core/lib/processor.js:185:38
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: 'ERR_OUT_OF_RANGE'
}
time="2024-05-07T16:01:54.549Z" level=info msg="sub-process exited" argo=true error="<nil>"
```